### PR TITLE
feat: remove inter as default font

### DIFF
--- a/src/tailwind-preset-wbw.js
+++ b/src/tailwind-preset-wbw.js
@@ -1,5 +1,3 @@
-const defaultTheme = require('tailwindcss/defaultTheme');
-
 /** @type {import('tailwindcss/tailwind-config').TailwindConfig} */
 module.exports = {
   theme: {
@@ -19,9 +17,6 @@ module.exports = {
           800: '#061e39',
           900: '#01060b',
         },
-      },
-      fontFamily: {
-        sans: ['Inter', ...defaultTheme.fontFamily.sans],
       },
       typography: {
         DEFAULT: {


### PR DESCRIPTION
Remove Inter as the default font for this preset just in case we want to use a different font across projects.