### PR TITLE
chore: set `access` to `public` on `publishConfig`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "clean": "rimraf dist",
     "build": "microbundle",


### PR DESCRIPTION
With this, we don't have to add `--access public` every time we run `npm publish`.